### PR TITLE
pin parcels<3.1.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - click
-  - parcels >= 3, < 4
+  - parcels >3, <3.1.0
   - pyproj >= 3, < 4
   - sortedcontainers == 2.4.0
   - opensimplex == 0.4.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "click",
-    "parcels >= 3, < 4",
+    "parcels >3, <3.1.0",
     "pyproj >= 3, < 4",
     "sortedcontainers == 2.4.0",
     "opensimplex == 0.4.5",

--- a/src/virtualship/expedition/input_data.py
+++ b/src/virtualship/expedition/input_data.py
@@ -97,9 +97,7 @@ class InputData:
 
         # make depth negative
         for g in fieldset.gridset.grids:
-            g._depth = (
-                -g._depth
-            )  # TODO maybe add a grid.negate_depth() method in Parcels?
+            g.depth = -g.depth
 
         # add bathymetry data
         bathymetry_file = directory.joinpath("bathymetry.nc")
@@ -139,7 +137,7 @@ class InputData:
 
         # make depth negative
         for g in fieldset.gridset.grids:
-            g._depth = -g._depth
+            g.depth = -g.depth
 
         # read in data already
         fieldset.computeTimeChunk(0, 1)
@@ -171,7 +169,7 @@ class InputData:
         # make depth negative
         for g in fieldset.gridset.grids:
             if max(g.depth) > 0:
-                g._depth = -g._depth
+                g.depth = -g.depth
 
         # read in data already
         fieldset.computeTimeChunk(0, 1)


### PR DESCRIPTION
API changes and warning changes in Parcels v.3.1.0 have caused some breakage in virtualship. Pinning to Parcels `<3.1.0` until we have a `.negate_depth` method in parcels, and the warning is fixed. After that is done we would need to pin to >3.1.0.

Changes:
- Revert #75
- Pin parcels<3.1.0

Related:
https://github.com/conda-forge/virtualship-feedstock/pull/1