### PR TITLE
Add deserialisation (i.e., field validators) for minute fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ ignore = [
     "E501",
     # consider `[meta, header, *data]` instead of concatenation
     "RUF005",
+    # Use `X | Y` in `isinstance` call instead of `(X, Y)`
+    "UP038",
     # multi-line-summary-first-line
     "D212",
     # one-blank-line-before-class

--- a/src/virtualship/expedition/ship_config.py
+++ b/src/virtualship/expedition/ship_config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pydantic
 import yaml
 
+from virtualship.utils import _validate_numeric_mins_to_timedelta
+
 
 class ArgoFloatConfig(pydantic.BaseModel):
     """Configuration for argos floats."""
@@ -37,6 +39,10 @@ class ADCPConfig(pydantic.BaseModel):
     def _serialize_period(self, value: timedelta, _info):
         return value.total_seconds() / 60.0
 
+    @pydantic.field_validator("period", mode="before")
+    def _validate_period(cls, value: int | float | timedelta) -> timedelta:
+        return _validate_numeric_mins_to_timedelta(value)
+
 
 class CTDConfig(pydantic.BaseModel):
     """Configuration for CTD instrument."""
@@ -55,6 +61,10 @@ class CTDConfig(pydantic.BaseModel):
     def _serialize_stationkeeping_time(self, value: timedelta, _info):
         return value.total_seconds() / 60.0
 
+    @pydantic.field_validator("stationkeeping_time", mode="before")
+    def _validate_stationkeeping_time(cls, value: int | float | timedelta) -> timedelta:
+        return _validate_numeric_mins_to_timedelta(value)
+
 
 class ShipUnderwaterSTConfig(pydantic.BaseModel):
     """Configuration for underwater ST."""
@@ -70,6 +80,10 @@ class ShipUnderwaterSTConfig(pydantic.BaseModel):
     @pydantic.field_serializer("period")
     def _serialize_period(self, value: timedelta, _info):
         return value.total_seconds() / 60.0
+
+    @pydantic.field_validator("period", mode="before")
+    def _validate_period(cls, value: int | float | timedelta) -> timedelta:
+        return _validate_numeric_mins_to_timedelta(value)
 
 
 class DrifterConfig(pydantic.BaseModel):
@@ -87,6 +101,10 @@ class DrifterConfig(pydantic.BaseModel):
     @pydantic.field_serializer("lifetime")
     def _serialize_lifetime(self, value: timedelta, _info):
         return value.total_seconds() / 60.0
+
+    @pydantic.field_validator("lifetime", mode="before")
+    def _validate_lifetime(cls, value: int | float | timedelta) -> timedelta:
+        return _validate_numeric_mins_to_timedelta(value)
 
 
 class XBTConfig(pydantic.BaseModel):

--- a/src/virtualship/utils.py
+++ b/src/virtualship/utils.py
@@ -156,6 +156,6 @@ def mfp_to_yaml(excel_file_path: str, yaml_output_path: str):  # noqa: D417
 
 def _validate_numeric_mins_to_timedelta(value: int | float | timedelta) -> timedelta:
     """Convert minutes to timedelta when reading."""
-    if isinstance(value, (int, float)):
-        return timedelta(minutes=value)
-    return value
+    if isinstance(value, timedelta):
+        return value
+    return timedelta(minutes=value)

--- a/src/virtualship/utils.py
+++ b/src/virtualship/utils.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from functools import lru_cache
 from importlib.resources import files
 from typing import TextIO
@@ -151,3 +152,10 @@ def mfp_to_yaml(excel_file_path: str, yaml_output_path: str):  # noqa: D417
 
     # Save to YAML file
     schedule.to_yaml(yaml_output_path)
+
+
+def _validate_numeric_mins_to_timedelta(value: int | float | timedelta) -> timedelta:
+    """Convert minutes to timedelta when reading."""
+    if isinstance(value, (int, float)):
+        return timedelta(minutes=value)
+    return value

--- a/tests/expedition/test_simulate_schedule.py
+++ b/tests/expedition/test_simulate_schedule.py
@@ -46,3 +46,11 @@ def test_simulate_schedule_too_far() -> None:
     result = simulate_schedule(projection, ship_config, schedule)
 
     assert isinstance(result, ScheduleProblem)
+
+
+def test_time_in_minutes_in_ship_schedule() -> None:
+    """Test whether the pydantic serializer picks up the time *in minutes* in the ship schedule."""
+    ship_config = ShipConfig.from_yaml("expedition_dir/ship_config.yaml")
+    assert ship_config.adcp_config.period == timedelta(minutes=5)
+    assert ship_config.ctd_config.stationkeeping_time == timedelta(minutes=20)
+    assert ship_config.ship_underwater_st_config.period == timedelta(minutes=5)


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- Closes #136
- [x] Tests added

Copied a test from https://github.com/OceanParcels/virtualship/commit/99955d7d231b76ef7dee9b51b776b5812c9fb6e4 as mentioned in #136.

The problem was that there was no deserialisation (i.e., "field validation" in pydantic terms) of the minutes to the timedelta objects (serialisation = model -> file, validation = file -> model). By default it treated the float as seconds.

Were there any other fields that are in minutes besides `ADCPConfig.period`, `CTDConfig.stationkeeping_time`, `ShipUnderwaterSTConfig.period`, and `DrifterConfig.lifetime` @erikvansebille  and @ammedd ?

Careful when merging this into [ship_spped_in_knots](https://github.com/OceanParcels/virtualship/compare/ship_spped_in_knots) to make sure the new Drifter.period also gets a deserialisation method like included in this PR. 