### PR TITLE
Log filter for reducing verbose-level of adcp and underwater

### DIFF
--- a/src/virtualship/instruments/ship_underwater_st.py
+++ b/src/virtualship/instruments/ship_underwater_st.py
@@ -1,10 +1,12 @@
 """Ship salinity and temperature."""
 
+import logging
 from pathlib import Path
 
 import numpy as np
 from parcels import FieldSet, ParticleSet, ScipyParticle, Variable
 
+from ..log_filter import DuplicateFilter
 from ..spacetime import Spacetime
 
 # we specifically use ScipyParticle because we have many small calls to execute
@@ -32,6 +34,7 @@ def simulate_ship_underwater_st(
     out_path: str | Path,
     depth: float,
     sample_points: list[Spacetime],
+    log_filter: bool = True,
 ) -> None:
     """
     Use Parcels to simulate underway data, measuring salinity and temperature at the given depth along the ship track in a fieldset.
@@ -40,6 +43,7 @@ def simulate_ship_underwater_st(
     :param out_path: The path to write the results to.
     :param depth: The depth at which to measure. 0 is water surface, negative is into the water.
     :param sample_points: The places and times to sample at.
+    :param log_filter: Whether to filter duplicate log messages (defaults to True). This is a bit of a hack, but it works and could be removed if changed in Parcels.
     """
     sample_points.sort(key=lambda p: p.time)
 
@@ -55,6 +59,12 @@ def simulate_ship_underwater_st(
     # define output file for the simulation
     # outputdt set to infinie as we want to just want to write at the end of every call to 'execute'
     out_file = particleset.ParticleFile(name=out_path, outputdt=np.inf)
+
+    #  whether to filter parcels duplicate log messages
+    if log_filter:
+        external_logger = logging.getLogger("parcels.tools.loggers")
+        for handler in external_logger.handlers:
+            handler.addFilter(DuplicateFilter())
 
     # iterate over each point, manually set lat lon time, then
     # execute the particle set for one step, performing one set of measurement
@@ -74,3 +84,9 @@ def simulate_ship_underwater_st(
             verbose_progress=False,
             output_file=out_file,
         )
+
+    # turn off log filter after .execute(), to prevent being applied universally to all loggers
+    # separate if statement from above to prevent error if log_filter is False
+    if log_filter:
+        for handler in external_logger.handlers:
+            handler.removeFilter(handler.filters[0])

--- a/src/virtualship/log_filter.py
+++ b/src/virtualship/log_filter.py
@@ -1,0 +1,17 @@
+"""Class for suppressing duplicate log messages in Python logging."""
+
+import logging
+
+
+class DuplicateFilter(logging.Filter):
+    """Logging filter for suppressing duplicate log messages."""
+
+    def __init__(self):
+        self.last_log = None
+
+    def filter(self, record):
+        current_log = record.getMessage()
+        if current_log != self.last_log:
+            self.last_log = current_log
+            return True
+        return False


### PR DESCRIPTION
Relates to bug identified in #155 

I've had a quick go at a bit of a hack to avoid the log being flooded with writing-to-file messages for every execution of adcp and underwater measurements. As I say it's a bit of a hack but it avoids having to change anything in Parcels, rather it simply prevents duplicate messages from being printed when running virtualship (but only for the adcp and underwater instruments and then it's switched off again).

The way I've written it means the log filter is applied by default for adcp and underwater instruments, but there is an option to switch it off in simulate_measurements.py by setting `log_filter` to `False` in `simulate_adcp`/`simulate_ship_underwater_st`. 

Also, not sure if it's a bit messy to have log_filter.py sitting in src/virtualship/, is there somewhere better to house it?

@erikvansebille @VeckoTheGecko @ammedd what do you think?