### PR TITLE
Change docs header link to VirtualShip website

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Home <self>
 user-guide/index
 api/index
 contributing/index
-VirtualShip <https://virtualship.oceanparcels.org/>
+VirtualShip Website <https://virtualship.oceanparcels.org/>
 ```
 
 ```{include} ../README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Home <self>
 user-guide/index
 api/index
 contributing/index
-OceanParcels <https://oceanparcels.org>
+VirtualShip <https://virtualship.oceanparcels.org/>
 ```
 
 ```{include} ../README.md


### PR DESCRIPTION
As raised in #203, the header in the VirtualShip docs has a link to the Parcels website, whereas a link to the VirtualShip website makes more sense. This PR swaps the Parcels link for VirtualShip.