### PR TITLE
Add openpyxl dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "copernicusmarine >= 2.2.2",
     "yaspin",
     "textual",
-    "openpyxl"
+    "openpyxl",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add `openpyxl` dependency to pyproject.toml. Missing dependency identified during in-class session.
