### PR TITLE
Turn off Underway_ST instrument by default

### DIFF
--- a/src/virtualship/static/expedition.yaml
+++ b/src/virtualship/static/expedition.yaml
@@ -71,7 +71,6 @@ instruments_config:
     min_depth_meter: -2.0
     fall_speed_meter_per_second: 6.7
     deceleration_coefficient: 0.00225
-  ship_underwater_st_config:
-    period_minutes: 5.0
+  ship_underwater_st_config: null
 ship_config:
   ship_speed_knots: 10.0


### PR DESCRIPTION
The Underway_ST instrument takes a long time to simulate. This should be addressed via #231 but for now I think it is best to default have it switched off: most users will not _need_ this measurement, and it can always be turned back on in `virtualship plan`. 