### PR TITLE
Argo floats in shallow waters

### DIFF
--- a/src/virtualship/instruments/argo_float.py
+++ b/src/virtualship/instruments/argo_float.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from typing import ClassVar
 
 import numpy as np
-
 from parcels import (
     AdvectionRK4,
     JITParticle,
@@ -12,6 +11,7 @@ from parcels import (
     StatusCode,
     Variable,
 )
+
 from virtualship.instruments.base import Instrument
 from virtualship.instruments.types import InstrumentType
 from virtualship.models.spacetime import Spacetime

--- a/tests/instruments/test_argo_float.py
+++ b/tests/instruments/test_argo_float.py
@@ -4,8 +4,8 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import xarray as xr
-
 from parcels import FieldSet
+
 from virtualship.instruments.argo_float import ArgoFloat, ArgoFloatInstrument
 from virtualship.models import Location, Spacetime
 


### PR DESCRIPTION
This PR introduces behaviour to the Argo float vertical movement kernel to avoid grounding on the seafloor in waters shallower than the typical Argo drifting depth (1000m) and max depth (2000m), following on from #262.

Previously, if a drifter was deployed in shallow waters an Argo in VirtualShip would artificially continue descending to beneath the sea floor as it tried to reach its drift depth or max depth for sampling. To illustrate the point, I have mocked up an Argo deployment [around the Norwegian sea](https://maps.app.goo.gl/nDx8Vth8FkNPn8AP8): see this 3D plot
[this 3D plot HTML file](https://github.com/user-attachments/files/24033935/argo_dev_olderror.html) with the trajectory + bathymetry map. It is also not advecting properly at the artificial depths.

Logic is now added to the `_argo_float_vertical_movement` kernel whereby if the particle reaches the seafloor it will stop descending and add 50m onto the particle depth. This is similar to how [VirtualFleet](https://github.com/euroargodev/VirtualFleet/blob/af03c3134abbb3b049fbfdb9817a70b50a651e4d/virtualargofleet/app_parcels.py#L94) opt to mimic real-life Argo behaviour. Now, repeating the same shelf-break deployment as above, the Argo will drift above the seafloor: see the [updated 3D plot HTML file](https://github.com/user-attachments/files/24034098/argo_dev_raise.html).

If the deployment location is < 50m depth then an error is thrown indicating that Argos cannot be deployed in such shallow waters. 

**Note:** I have arranged a meeting with the Argo team next week to further discuss realistic Argo behaviours. So, this may be subject to change in a future PR but the basis for dealing with seafloor grounding is established in the current PR.

---- 

- [x] Tests updated