### PR TITLE
Update datetimes in `static/expedition.yaml`

### DIFF
--- a/src/virtualship/static/expedition.yaml
+++ b/src/virtualship/static/expedition.yaml
@@ -13,23 +13,23 @@ schedule:
       location:
         latitude: 0.01
         longitude: 0.01
-      time: 1998-01-01 01:00:00
+      time: 1998-01-02 01:00:00
     - instrument:
         - ARGO_FLOAT
       location:
         latitude: 0.02
         longitude: 0.02
-      time: 1998-01-01 02:00:00
+      time: 1998-01-03 02:00:00
     - instrument:
         - XBT
       location:
         latitude: 0.03
         longitude: 0.03
-      time: 1998-01-01 03:00:00
+      time: 1998-01-04 03:00:00
     - location:
         latitude: 0.03
         longitude: 0.03
-      time: 1998-01-01 03:00:00
+      time: 1998-01-05 03:00:00
 instruments_config:
   adcp_config:
     num_bins: 40


### PR DESCRIPTION
As identified in #281, the waypoints in the example/static `expedition.yaml` cannot be reached in time. This means if you just run the example expedition workflow (`virtualship init TEST` -> `virtualship run TEST`) it already fails.

Therefore, this PR updates the datetimes to make it a valid schedule by default, adding 1 day to each, as @VeckoTheGecko does in #281.