### PR TITLE
Generalise dir names in SURF instructions

### DIFF
--- a/docs/user-guide/tutorials/surf_research_cloud_setup.ipynb
+++ b/docs/user-guide/tutorials/surf_research_cloud_setup.ipynb
@@ -26,7 +26,7 @@
     "Navigate to the [SURF Research Cloud Dashboard](https://portal.live.surfresearchcloud.nl/), and click \"access\" on the shared workspace.\n",
     "\n",
     "<div class=\"alert alert-block alert-success\"> \n",
-    "<b>**TIP**:</b> You may sometimes hit a server error when accessing the workspace. If this happens, keep on trying (refresh), as the server spin-up can be a bit overloaded at times, but should get through eventually. Unfortunately this is out of our control.\n",
+    "<b>**TIP**:</b> You may sometimes hit a server error when accessing the workspace. If this happens, keep on trying (refresh), as the server spin-up can be a bit overloaded at times, but should get through eventually. Unfortunately this is out of our control. Clearing your browser cache and cookies, and/or trying via an incognito/private window may also help.\n",
     "</div>\n",
     "\n",
     "## 3. Jupyter workspace layout and additional config\n",


### PR DESCRIPTION
This PR makes small changes to the SURF set up guide, generalising the name of the example storage directory to suit use in different courses, avoiding specific references to UU course names.