### PR TITLE
Add detail on multiple drifter deployments to `expedition.yaml` guide

### DIFF
--- a/docs/user-guide/tutorials/working_with_expedition_yaml.md
+++ b/docs/user-guide/tutorials/working_with_expedition_yaml.md
@@ -78,6 +78,10 @@ This section contains a list of `waypoints` that define the expedition's route. 
 Full list of instruments supported for deployment at waypoints (case-sensitive): `CTD`, `CTD_BGC`, `DRIFTER`, `ARGO_FLOAT`, `XBT` (or `null`).
 ```
 
+```{tip}
+You can do multiple `DRIFTER` deployments at the same waypoint by adding multiple `DRIFTER` entries in the list (on separate lines). Note, this is not the case for other instruments, e.g. `CTD`, which can only be deployed once at a given waypoint.
+```
+
 - **Location (`location`)**: The geographical coordinates (latitude and longitude) of the waypoint. These must be in decimal degrees (DD) format and within valid ranges: latitude between -90 and 90, longitude between -180 and 180.
 
 - **Time (`time`)**: The scheduled time for reaching the waypoint, specifically in YYYY-MM-DD HH:MM:SS format.


### PR DESCRIPTION
Adds the point that multiple drifters can be deployed at a given waypoint and how users can do so directly in the `expedition.yaml` file.