### PR TITLE
Warning on overwriting `results` dir

### DIFF
--- a/src/virtualship/cli/_run.py
+++ b/src/virtualship/cli/_run.py
@@ -133,7 +133,7 @@ def _run(
 
     # delete and create results directory
     results_dir = expedition_dir.joinpath(RESULTS)
-    _warn_overwrite(results_dir)
+    _warn_overwrite_results_dir(results_dir)
 
     if os.path.exists(results_dir):
         shutil.rmtree(results_dir)


### PR DESCRIPTION
This PR adds a warning stage if the `results` dir already exists in the expedition dir. If it does it will give the option to continue and overwrite the previous results, and also provides messaging that `results` should be moved/renamed if the user doesn't want to overwrite it.

Closes #261 