### PR TITLE
Fix time adjustment buttons after copying from previous waypoint

### DIFF
--- a/src/virtualship/cli/_plan.py
+++ b/src/virtualship/cli/_plan.py
@@ -893,6 +893,17 @@ class WaypointWidget(Static):
                         )
                         if prev_switch and curr_switch:
                             curr_switch.value = prev_switch.value
+
+                    # hard update self.waypoint.time to match new values as shown in UI
+                    year = int(self.query_one(f"#wp{self.index}_year").value)
+                    month = int(self.query_one(f"#wp{self.index}_month").value)
+                    day = int(self.query_one(f"#wp{self.index}_day").value)
+                    hour = int(self.query_one(f"#wp{self.index}_hour").value)
+                    minute = int(self.query_one(f"#wp{self.index}_minute").value)
+                    self.waypoint.time = datetime.datetime(
+                        year, month, day, hour, minute, 0
+                    )
+
         except Exception as e:
             raise UnexpectedError(unexpected_msg_compose(e)) from None
 


### PR DESCRIPTION
Following #296 (thanks @ammedd for pointing this out), this PR adds a hard update of the underlying waypoint object time at the end of the `copy_from_previous()` method, to ensure that the buttons to add/subtract time onto the waypoints modify the correct datetime _after_ copying from the previous waypoint.

Closes #296 