### PR TITLE
Adjust the messaging user receives for in-port messaging

### DIFF
--- a/src/virtualship/models/checkpoint.py
+++ b/src/virtualship/models/checkpoint.py
@@ -167,7 +167,11 @@ class Checkpoint(pydantic.BaseModel):
                             if problem["problem_waypoint_i"] is not None
                             else new_schedule.waypoints[0].time
                         )
-                        current_time = problem_waypoint.time + time_elapsed
+                        current_time = (
+                            problem_waypoint.time + time_elapsed
+                            if problem["problem_waypoint_i"] is not None
+                            else self.past_schedule.waypoints[0].time + time_elapsed
+                        )
 
                         raise CheckpointError(
                             f"The problem encountered in previous simulation has not been resolved in the schedule! Please adjust the schedule to account for delays caused by the problem (by using `virtualship plan` or directly editing the {EXPEDITION} file).\n\n"


### PR DESCRIPTION
When a user gets an in-port 'problem' and then makes schedule adjustments but the issue is still not resolved, the `current_time` in the messaging which is fed forward by the `checkpoint.verify` method to the user should be relative to the _old_ schedule. In port problems are a special case where the reference time is fixed.