### PR TITLE
Fix drifter depth test

### DIFF
--- a/tests/instruments/test_drifter.py
+++ b/tests/instruments/test_drifter.py
@@ -5,8 +5,8 @@ from typing import ClassVar
 
 import numpy as np
 import xarray as xr
-
 from parcels import FieldSet
+
 from virtualship.instruments.drifter import Drifter, DrifterInstrument
 from virtualship.models import Location, Spacetime
 from virtualship.models.expedition import Waypoint


### PR DESCRIPTION
The forcing FieldSet in `test_drifter_depths` is supposed to have different values at the surface and depth to test that drifters are being deployed properly at different depths. However, the previous version used `np.random.randint()` as a multiplier to make new values at depth but _could_ be the same as the surface if `np.random.randint == 1`. Hence, some but not all of the testing failed when #306 was merged. 

This PR updates the test to give a consistently different field at depth, so that the FieldSet does not interfere with testing the actual drifter logic.