### PR TITLE
Fix Pixi caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       pixi-version: ${{ steps.pixi-lock.outputs.pixi-version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: Parcels-code/pixi-lock/create-and-cache@9a2866f8258b87a3c616d5ad7d51c6cd853df78b
+      - uses: Parcels-code/pixi-lock/create-and-cache@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         id: pixi-lock
       - uses: actions/upload-artifact@v6 # make available as an artifact for local testing
         with:
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: Parcels-code/pixi-lock/restore@9a2866f8258b87a3c616d5ad7d51c6cd853df78b
+      - uses: Parcels-code/pixi-lock/restore@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
         with:
           cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
       - uses: prefix-dev/setup-pixi@v0.9.4
@@ -75,7 +75,7 @@ jobs:
 #       - uses: actions/checkout@v4
 #         with:
 #           fetch-depth: 0
-#       - uses: Parcels-code/pixi-lock/restore@9a2866f8258b87a3c616d5ad7d51c6cd853df78b
+#       - uses: Parcels-code/pixi-lock/restore@38495788b79a5ff26009aecc15daa9a8310b8832 # v0.1.0
 #         with:
 #           cache-key: ${{ needs.cache-pixi-lock.outputs.cache-key }}
 #       - uses: prefix-dev/setup-pixi@v0.9.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pixi-environment: ["test-py312"]
+        pixi-environment: ["test-latest"]
         runs-on: [ubuntu-latest, windows-latest, macos-14]
         include:
           - pixi-environment: "test-py310"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ env:
   # Many color libraries just need this to be set to any value, but at least
   # one distinguishes color depth, where "3" -> "256-bit color".
   FORCE_COLOR: 3
-  PIXI_VERSION: "v0.63.2"
 
 jobs:
   cache-pixi-lock:
@@ -31,8 +30,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Parcels-code/pixi-lock/create-and-cache@9a2866f8258b87a3c616d5ad7d51c6cd853df78b
         id: pixi-lock
-        with:
-          pixi-version: ${{env.PIXI_VERSION}}
       - uses: actions/upload-artifact@v6 # make available as an artifact for local testing
         with:
           name: pixi-lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pixi-environment: ["test-py310", "test-py312"]
+        pixi-environment: ["test-py312"]
         runs-on: [ubuntu-latest, windows-latest, macos-14]
+        include:
+          - pixi-environment: "test-py310"
+            runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # pixi environments
 .pixi/*
 !.pixi/config.toml
+pixi.lock
 
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Description:
- Ignored the pixi lock
- updated the version of the pixi lock action (no longer requires version to be explicitly set)

- Closes #320 
- [x] Tests added
- [x] PR adheres with the current [design document](./design-doc.md) (or design document is updated)
