### PR TITLE
New `analysis` pixi environment

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -58,6 +58,16 @@ ipykernel = "*"
 [feature.notebooks.tasks]
 tests-notebooks = "pytest --nbval-lax docs/"
 
+[feature.analysis.dependencies]
+jupyterlab = ">=4,<5"
+ipykernel = ">=7,<8"
+plotly = ">=6,<7"
+nbformat = "*"
+ipywidgets = "*"
+
+[feature.analysis.tasks]
+lab = "jupyter lab"
+
 [feature.docs.dependencies]
 sphinx = ">=7.0"
 myst-parser = ">=0.13"
@@ -92,6 +102,7 @@ test-py310 = { features = ["test", "py310"] }
 test-py311 = { features = ["test", "py311"] }
 test-py312 = { features = ["test", "py312"] }
 test-notebooks = { features = ["test", "notebooks"], solve-group = "test" }
+analysis = { features = ["analysis"], solve-group = "analysis" }
 docs = { features = ["docs"], solve-group = "docs" }
 typing = { features = ["typing"], solve-group = "typing" }
 pre-commit = { features = ["pre-commit"], no-default-feature = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -96,13 +96,12 @@ lxml = "*"
 typing = "mypy src/virtualship --install-types"
 
 [environments]
-default = { features = ["test", "notebooks", "typing", "pre-commit"] }
+default = { features = ["test", "notebooks", "typing", "pre-commit", "analysis"] }
 test-latest = { features = ["test"], solve-group = "test" }
 test-py310 = { features = ["test", "py310"] }
 test-py311 = { features = ["test", "py311"] }
 test-py312 = { features = ["test", "py312"] }
 test-notebooks = { features = ["test", "notebooks"], solve-group = "test" }
-analysis = { features = ["analysis"], solve-group = "analysis" }
 docs = { features = ["docs"], solve-group = "docs" }
 typing = { features = ["typing"], solve-group = "typing" }
 pre-commit = { features = ["pre-commit"], no-default-feature = true }


### PR DESCRIPTION
It's useful to have a few extra dependencies when experimenting/testing code changes with VirtualShip expeditions, plus for post-processing results. Therefore, this PR adds a new pixi environment (called `analysis`) to the project with additional dependencies including `plotly`, `jupyterlab`, `ipykernel` etc. 

@VeckoTheGecko is this the best way to go about this kind of thing with pixi? 