### PR TITLE
Breaking change in `textual` dependency

### DIFF
--- a/src/virtualship/cli/_plan.py
+++ b/src/virtualship/cli/_plan.py
@@ -736,7 +736,7 @@ class WaypointWidget(Static):
                         id=f"wp{self.index}_year",
                         value=int(self.waypoint.time.year)
                         if self.waypoint.time
-                        else Select.BLANK,
+                        else Select.NULL,
                         prompt="YYYY",
                         classes="year-select",
                     )
@@ -746,7 +746,7 @@ class WaypointWidget(Static):
                         id=f"wp{self.index}_month",
                         value=int(self.waypoint.time.month)
                         if self.waypoint.time
-                        else Select.BLANK,
+                        else Select.NULL,
                         prompt="MM",
                         classes="month-select",
                     )
@@ -756,7 +756,7 @@ class WaypointWidget(Static):
                         id=f"wp{self.index}_day",
                         value=int(self.waypoint.time.day)
                         if self.waypoint.time
-                        else Select.BLANK,
+                        else Select.NULL,
                         prompt="DD",
                         classes="day-select",
                     )
@@ -766,7 +766,7 @@ class WaypointWidget(Static):
                         id=f"wp{self.index}_hour",
                         value=int(self.waypoint.time.hour)
                         if self.waypoint.time
-                        else Select.BLANK,
+                        else Select.NULL,
                         prompt="hh",
                         classes="hour-select",
                     )
@@ -775,7 +775,7 @@ class WaypointWidget(Static):
                     minute_value = (
                         int(self.waypoint.time.minute)
                         if self.waypoint.time
-                        else Select.BLANK
+                        else Select.NULL
                     )
 
                     # if the current minute is not a multiple of 5, add it to the options

--- a/tests/cli/test_plan.py
+++ b/tests/cli/test_plan.py
@@ -150,3 +150,52 @@ async def test_UI_changes():
 
     # cleanup
     shutil.rmtree(tmpdir)
+
+
+@pytest.mark.asyncio
+async def test_UI_opens_with_null_time_and_instrument():
+    """Test that the UI opens correctly when waypoints have time: null and instrument: null."""
+    tmpdir = Path(tempfile.mkdtemp())
+
+    instruments_config = InstrumentsConfig.model_validate(
+        yaml.safe_load(get_example_expedition()).get("instruments_config")
+    )
+    ship_config = yaml.safe_load(get_example_expedition()).get("ship_config")
+    waypoints = [
+        Waypoint(
+            location=Location(0, 0),
+            time=datetime(2022, 1, 1, 0, 0, 0),
+            instrument=["CTD"],
+        ),
+        Waypoint(
+            location=Location(0.01, 0.01),
+            time=None,
+            instrument=None,
+        ),
+        Waypoint(
+            location=Location(0.02, 0.02),
+            time=None,
+            instrument=None,
+        ),
+    ]
+    expedition = Expedition(
+        schedule=Schedule(waypoints=waypoints),
+        instruments_config=instruments_config,
+        ship_config=ship_config,
+    )
+
+    expedition.to_yaml(tmpdir / EXPEDITION)
+
+    app = PlanApp(path=tmpdir)
+
+    async with app.run_test(size=(120, 100)) as pilot:
+        await pilot.pause(0.5)
+
+        plan_screen = pilot.app.screen
+        expedition_editor = plan_screen.query_one(ExpeditionEditor)
+
+        # verify the app opened without errors by checking the editor loaded
+        assert expedition_editor is not None
+
+    # cleanup
+    shutil.rmtree(tmpdir)


### PR DESCRIPTION
Relates to plan UI: `textual` [v8.0.0](https://github.com/Textualize/textual/releases/tag/v8.0.0) has a breaking API change, i.e. `Select.BLANK` must now be `Select.NULL`. 

New test added to check that empty waypoints are handled properly when launching UI, fails in old version, passes in this PR. 

Closes none