### PR TITLE
Argo drift time must be less than cycle time

### DIFF
--- a/src/virtualship/cli/_plan.py
+++ b/src/virtualship/cli/_plan.py
@@ -7,6 +7,7 @@ from textual import on
 from textual.app import App, ComposeResult
 from textual.containers import Container, Horizontal, VerticalScroll
 from textual.dom import NoMatches
+from textual.markup import escape
 from textual.screen import ModalScreen, Screen
 from textual.validation import Function, Integer
 from textual.widgets import (
@@ -530,11 +531,25 @@ class ExpeditionEditor(Static):
                 kwargs["sensors"] = (
                     sensors if sensors else _default_sensors(config_class)
                 )
-            setattr(
-                self.expedition.instruments_config,
-                instrument_name,
-                config_class(**kwargs),
-            )
+            try:
+                setattr(
+                    self.expedition.instruments_config,
+                    instrument_name,
+                    config_class(**kwargs),
+                )
+            except (ValueError, Exception) as e:
+                # catch validation errors, e.g. drift_days >= cycle_days
+                if isinstance(e, ValueError):
+                    title = info.get("title", instrument_name.replace("_", " ").title())
+                    raise UserError(f"'{title}' configuration error: {e}") from None
+                elif (  # pydantic validation error
+                    hasattr(e, "__class__")
+                    and "ValidationError" in e.__class__.__name__
+                ):
+                    title = info.get("title", instrument_name.replace("_", " ").title())
+                    raise UserError(f"'{title}' configuration error: {e}") from None
+                else:
+                    raise
 
     def _update_schedule(self):
         for i, wp in enumerate(self.expedition.schedule.waypoints):
@@ -1150,7 +1165,9 @@ class PlanScreen(Screen):
 
         except Exception as e:
             self.notify(
-                f"*** Error saving changes ***:\n\n{e}\n",
+                escape(
+                    f"*** Error saving changes ***:\n\n{e}\n"
+                ),  # escape avoids issues with special characters being interpreted as markup
                 severity="error",
                 timeout=20,
             )

--- a/src/virtualship/models/expedition.py
+++ b/src/virtualship/models/expedition.py
@@ -293,6 +293,15 @@ class ArgoFloatConfig(_InstrumentConfigMixin, pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(populate_by_name=True)
 
+    @pydantic.model_validator(mode="after")
+    def _drift_days_less_than_cycle_days(self) -> ArgoFloatConfig:
+        """Ensure drift_days is less than cycle_days."""
+        if self.drift_days >= self.cycle_days:
+            raise ValueError(
+                f"drift_days ({self.drift_days}) must be less than cycle_days ({self.cycle_days}). "
+            )
+        return self
+
 
 @register_instrument_config(InstrumentType.ADCP)
 class ADCPConfig(_InstrumentConfigMixin, pydantic.BaseModel):

--- a/tests/instruments/test_argo_float.py
+++ b/tests/instruments/test_argo_float.py
@@ -229,3 +229,32 @@ def test_argo_config_unsupported_sensor_rejected():
             stationkeeping_time_minutes=10,
             sensors=[SensorConfig(sensor_type=SensorType.OXYGEN)],
         )
+
+
+def test_argo_config_drift_days_exceeds_cycle_days():
+    """ArgoFloatConfig should reject drift_days >= cycle_days."""
+    base_kwargs = {
+        "min_depth_meter": 0.0,
+        "max_depth_meter": -2000,
+        "drift_depth_meter": -1000,
+        "vertical_speed_meter_per_second": -0.10,
+        "lifetime": timedelta(days=30),
+        "stationkeeping_time_minutes": 10,
+    }
+
+    # drift_days > cycle_days should raise validation error
+    with pytest.raises(
+        pydantic.ValidationError, match="drift_days .* must be less than cycle_days"
+    ):
+        ArgoFloatConfig(**base_kwargs, cycle_days=10, drift_days=15)
+
+    # drift_days == cycle_days should also raise validation error
+    with pytest.raises(
+        pydantic.ValidationError, match="drift_days .* must be less than cycle_days"
+    ):
+        ArgoFloatConfig(**base_kwargs, cycle_days=10, drift_days=10)
+
+    # check a valid configuration: drift_days < cycle_days
+    config = ArgoFloatConfig(**base_kwargs, cycle_days=10, drift_days=9)
+    assert config.drift_days == 9
+    assert config.cycle_days == 10


### PR DESCRIPTION
This PR adds a model validation step to the `ArgoFloatConfig` ensuring that the drift time is always less than the cycle time.

New test added which ensures errors are thrown when the invalid configuration (drift time > cycle time or drift time == cycle_time) is used.

Closes #157 

---- 

It could be worth considering moving some of these validation checks to the Instrument classes themselves (rather than the Pydantic models), to make those more self-contained and portable for more Pythonic use of instruments... but I think that refactoring would follow in a future PR (i.e. #346)